### PR TITLE
Fix judgments with percent sign

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -994,7 +994,7 @@ function texMakeExpex (parsedDiv)
       judgeMax = judgements[i]
     end
   end
-  local judgeOffset = "[*="..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%&_{}~^])", "\\%1").."]"
+  local judgeOffset = "[*="..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%%&_{}~^])", "\\%1").."]"
 
   for i=1,#kind do
     if judgements[i] == nil then 
@@ -1189,7 +1189,7 @@ function texMakeGb4e (parsedDiv)
       judgeMax = judgements[i]
     end
   end
-  local judgeOffset = "\\judgewidth{"..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%&_{}~^])", "\\%1").."}"
+  local judgeOffset = "\\judgewidth{"..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%%&_{}~^])", "\\%1").."}"
 
   for i=1,#kind do
     if judgements[i] == nil then 
@@ -1290,7 +1290,7 @@ function texMakeLangsci (parsedDiv)
       judgeMax = judgements[i]
     end
   end
-  local judgeOffset = "\\judgewidth{"..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%&_{}~^])", "\\%1").."}"
+  local judgeOffset = "\\judgewidth{"..string.gsub(pandoc.utils.stringify(judgeMax), "([#$%%&_{}~^])", "\\%1").."}"
 
   for i=1,#kind do
     if judgements[i] == nil then


### PR DESCRIPTION
This fixes LaTeX compilation errors with examples like:


```md
::: ex
^% This example is accepted in some dialects.
:::
```

Because `%` is reserved for character classes in Lua strings (https://stackoverflow.com/questions/6935272), we need to use `%%` here. Otherwise, the `%` is not escaped and TeX sees a comment.