### PR TITLE
Two [%u%d] to one [%u%d] to resolve issue #12

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -444,7 +444,7 @@ end
 function formatGlossLine (s)
   -- turn uppercase in gloss into small caps
   local split = {}
-  for lower,upper in string.gmatch(s, "(.-)([%u%d][%u%d]+)") do
+  for lower,upper in string.gmatch(s, "(.-)([%u%d]+)") do
     if lower ~= "" then
       lower = pandoc.Str(lower)
       table.insert(split, lower)
@@ -452,7 +452,7 @@ function formatGlossLine (s)
     upper = pandoc.SmallCaps(pandoc.text.lower(upper))
     table.insert(split, upper)
   end
-  for leftover in string.gmatch(s, "[%u%d][%u%d]+(.-[^%u%s])$") do
+  for leftover in string.gmatch(s, "[%u%d]+(.-[^%u%s])$") do
     leftover = pandoc.Str(leftover)
     table.insert(split, leftover)
   end


### PR DESCRIPTION
The latest pandoc-ling 2a1e55af5d976dab5557affdbee95fee05446ed4 as of July 4, 2022, may not render one-character abbreviations such as `Q`, `A`, `S`, `P`, `F`, `M` and so on, which are listed in Leipzig Glossing Rules. This issues was reported as #12.

![image](https://user-images.githubusercontent.com/42314553/177122215-5865c286-7f5a-4a0b-8649-8f82f76c3e31.png)

I think the issue should be resolved if `[%u%d][%u%d]` in l.447 and l.455 of `pandoc-ling.lua` is replaced with one `[%u%d]`.

https://github.com/cysouw/pandoc-ling/blob/2a1e55af5d976dab5557affdbee95fee05446ed4/pandoc-ling.lua#L447
https://github.com/cysouw/pandoc-ling/blob/2a1e55af5d976dab5557affdbee95fee05446ed4/pandoc-ling.lua#L455