### PR TITLE
Check if div has content before indexing

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -229,7 +229,8 @@ function processDiv (div)
 
   -- keep track of chapters (header == 1)
   -- included in this loop by trick "addDivToHeader"
-  if div.content[1].tag == "Header" and div.content[1].classes[1] == "restart"  then
+  if #div.content > 0 and div.content[1].tag == "Header" and
+      div.content[1].classes[1] == "restart"  then
     chapter = chapter + 1
     counterInChapter = 0
     div.content[1].attr = {id = div.content[1].identifier, class = ""}


### PR DESCRIPTION
Thank you for your work on `pandoc-ling`.

This commit just adds a guard in the function `processDiv` which checks that a `Div` has content inside it before indexing into the content array. This makes the filter compatible with `Div`s that have no content inside them, which are supported by pandoc's model (though a bit of a strange corner case), and which I sometimes use in my own filters as placeholders for `Block` like elements which I calculate elsewhere then substitute into the document, e.g.

```
::: {.block-element}
:::
```

With the current code, if `pandoc-ling` is run before this substitution occurs, it attempts to index into the `Div`'s content and fails.