### PR TITLE
Format HTML glosses using abbr tag

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -45,10 +45,17 @@ local latexPackage = "linguex"
 local topDivision = "section"
 local noFormat = false
 local documentclass = "article"
+local abbreviations = {} -- default abbreviations
 
 function getUserSettings (meta)
   if meta.formatGloss ~= nil then
     formatGloss = meta.formatGloss
+  end
+  -- Load user provided glossing abbreviations, overriding any default abbreviations
+  if meta.pandocLingAbbreviations ~= nil then
+    for k, v in pairs(meta.pandocLingAbbreviations) do
+      abbreviations[k] = pandoc.utils.stringify(v)
+    end
   end
   if meta.samePage ~= nil then
     samePage = meta.samePage
@@ -451,6 +458,15 @@ end
 -- helper functions for (lists of) inlines
 ------------------------------------------
 
+local abbreviationFormatter = {
+  html = function(gloss, full)
+    return pandoc.RawInline("html", string.format(
+      '<abbr title="%s">%s</abbr>',
+      full,
+      pandoc.text.lower(gloss)))
+  end,
+}
+
 function formatGlossLine (s)
   -- turn uppercase in gloss into small caps
   local split = {}
@@ -459,7 +475,11 @@ function formatGlossLine (s)
       lower = pandoc.Str(lower)
       table.insert(split, lower)
     end
-    upper = pandoc.SmallCaps(pandoc.text.lower(upper))
+    if abbreviations[upper] ~= nil and abbreviationFormatter[FORMAT] ~= nil then
+      upper = pandoc.SmallCaps(abbreviationFormatter[FORMAT](upper, abbreviations[upper]))
+    else
+      upper = pandoc.SmallCaps(pandoc.text.lower(upper))
+    end
     table.insert(split, upper)
   end
   for leftover in string.gmatch(s, "[%u%d]+([‑%-][^‑%-]-%l+)$") do


### PR DESCRIPTION
@cysouw if you could please review and provide feedback whenever you have a moment. This commit adds functionality to output HTML's `abbr` tag in the glossing line with the abbreviation's full gloss displayed upon hover when a glossing abbreviation is recognized.

Users may specify custom abbreviations as a YAML map in the document metadata, under the option `pandocLingAbbreviations`, which will override any default glossing abbreviations. Abbreviations must be specified in ALL CAPS. No defaults are currently provided.

After some consideration, I decided to output the gloss as a Pandoc `SmallCaps` node containing a `RawInline`, as opposed to bare `RawInline` with the smallcaps class baked into the HTML. While this results in more verbose and less semantic HTML output, I ultimately settled on this option as it preserves more information in the Pandoc AST itself, which downstream filters might eventually want to use.

As stated above, no default glossing abbreviations are provided in this commit. I can add these if there's any interest in this feature. Suggestions for where to find a comprehensive list are also welcome.

This commit only implements the functionality for HTML output, but it provides a small scaffold for implementing similar functionality for latex output as well, which I believe could be implemented quite straightforwardly using the `pdfcomment` package. Again, if there is interest, I could look into doing this.