### PR TITLE
move citations to after quotes

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -444,11 +444,14 @@ end
 
 function getTrans (line)
   if formatGloss then
-    -- remove quotes and add singlequote througout
-    if line[1].tag == "Quoted" then
-      line = line[1].content
+    -- Check if user provided their own quotes
+    if line[1] and line[1].tag == "Quoted" then
+      -- User provided quotes - preserve everything as-is
+      -- This allows users to manually handle citations and formatting
+      return pandoc.Plain(line)
     end
     
+    -- No user quotes - apply automatic formatting
     -- Extract trailing citations and spaces to place them outside the quotes
     local citations = {}
     local i = #line

--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -448,7 +448,35 @@ function getTrans (line)
     if line[1].tag == "Quoted" then
       line = line[1].content
     end
+    
+    -- Extract trailing citations and spaces to place them outside the quotes
+    local citations = {}
+    local i = #line
+    while i >= 1 do
+      if line[i].tag == "Cite" or line[i].tag == "Space" then
+        table.insert(citations, 1, line[i])
+        i = i - 1
+      else
+        break
+      end
+    end
+    
+    -- Remove extracted citations from line
+    for j = 1, #citations do
+      table.remove(line)
+    end
+    
+    -- Quote the remaining content
     line = pandoc.Quoted("SingleQuote", line)
+    
+    -- Append citations after the quote
+    if #citations > 0 then
+      local result = {line}
+      for _, cite in ipairs(citations) do
+        table.insert(result, cite)
+      end
+      line = result
+    end
   end
   return pandoc.Plain(line)
 end


### PR DESCRIPTION
Before:

	b. 		Deze 	tweede 	zin 	heeft 	geen 	header.
			dem 	second 	sentence 	have.3sg.pres 	no 	header.
			‘This second sentence does not have a header. (Vries 2010)’

after:

	b. 		Deze 	tweede 	zin 	heeft 	geen 	header.
			dem 	second 	sentence 	have.3sg.pres 	no 	header.
			‘This second sentence does not have a header.’ (Vries 2010)
