### PR TITLE
Add direct sub-example ID references

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -28,6 +28,7 @@ local counter = 0 -- actual numbering of examples
 local chapter = 0 -- numbering of chapters
 local counterInChapter = 0 -- counter reset for each chapter
 local indexEx = {} -- global lookup for example IDs
+local subExIndex = {} -- lookup for sub-example IDs: subExID -> {parentExID, letter}
 local orderInText = 0 -- order of references for resolving "Next"-style references
 local indexRef = {} -- key/value: order in text = refID/exID
 local rev_indexRef = {} -- "reversed" indexRef, i.e. key/value: refID/exID = order-number in text
@@ -273,7 +274,7 @@ function processDiv (div)
       example = parsedDiv.examples
       example = pandocMakeExample(parsedDiv)
       example = pandoc.Div(example)
-      example.attr = {id = "ex"..parsedDiv.number}
+      example.attr = {id = parsedDiv.exID}
     end
 
     -- return to global setting
@@ -333,6 +334,7 @@ function parseDiv (div)
   local judgements = {}
   local examples = {}
   local kind = {}
+  local subExIDs = {} -- track sub-example IDs
 
   if noFormat then
     preamble = nil
@@ -341,10 +343,52 @@ function parseDiv (div)
     examples[1] = div
   elseif data.tag == "OrderedList" or data.tag == "BulletList" then
     for i=1,#data.content do
+      -- Extract sub-example ID if present, BEFORE calling parseExample
+      local firstBlock = data.content[i][1]
+      if firstBlock.tag == "LineBlock" then
+        -- For interlinear examples, check the first line (header/label line)
+        local firstLine = firstBlock.content[1]
+        local lineText = pandoc.utils.stringify(firstLine)
+        local subID = string.match(lineText, "{#([^}]+)}")
+        if subID then
+          subExIDs[i] = subID
+          -- Remove the {#id} from the actual content
+          for j = #firstLine, 1, -1 do
+            local elem = firstLine[j]
+            if elem.tag == "Str" and string.match(elem.text, "{#[^}]+}") then
+              firstLine[j] = pandoc.Str(string.gsub(elem.text, "%s*{#[^}]+}", ""))
+              break
+            end
+          end
+        end
+      elseif firstBlock.tag == "Para" or firstBlock.tag == "Plain" then
+        -- For single-line examples, check the content
+        local content = firstBlock.content
+        local contentText = pandoc.utils.stringify(content)
+        local subID = string.match(contentText, "{#([^}]+)}")
+        if subID then
+          subExIDs[i] = subID
+          -- Remove the {#id} from the actual content
+          for j = #content, 1, -1 do
+            local elem = content[j]
+            if elem.tag == "Str" and string.match(elem.text, "{#[^}]+}") then
+              content[j] = pandoc.Str(string.gsub(elem.text, "%s*{#[^}]+}", ""))
+              break
+            end
+          end
+        end
+      end
+      -- Now parse the example (after ID extraction and removal)
       judgements[i], examples[i], kind[i] = parseExample(data.content[i][1])
     end
   else
     judgements[1], examples[1], kind[1] = parseExample(data)
+  end
+  
+  -- Register sub-example IDs in global index
+  for i, subID in pairs(subExIDs) do
+    local letter = string.char(96 + i) -- a, b, c, etc.
+    subExIndex[subID] = {parentExID = exID, letter = letter}
   end
 
   return { 	kind = kind, -- list of single/interlinear
@@ -352,7 +396,8 @@ function parseDiv (div)
             judgements = judgements, -- judgements is list of Str
             examples = examples,   -- examples is list of (list of) Plain
             number = number,       -- number, exID are bare string
-            exID = exID 
+            exID = exID,
+            subExIDs = subExIDs    -- map: index -> sub-example ID
           }
 end
 
@@ -551,8 +596,16 @@ function pandocMakeExample (parsedDiv)
     example[1] = pandocNoFormat(parsedDiv)
   elseif #kind == 1 and kind[1] == "single" then
     example[1] = pandocMakeSingle(parsedDiv)
+    -- Set ID if this single example has a sub-example ID
+    if parsedDiv.subExIDs and parsedDiv.subExIDs[1] then
+      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1])
+    end
   elseif #kind == 1 and kind[1] == "interlinear" then
     example[1] = pandocMakeInterlinear(parsedDiv)
+    -- Set ID if this interlinear has a sub-example ID
+    if parsedDiv.subExIDs and parsedDiv.subExIDs[1] then
+      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1])
+    end
   elseif #kind > 1 and onlySingle then
     example[1] = pandocMakeList(parsedDiv)
   else
@@ -841,6 +894,10 @@ function pandocMakeMixedList (parsedDiv)
     if parsedDiv.kind[i] == "interlinear" then
       local label = i
       result[resultCount]        = pandocMakeInterlinear(parsedDiv, label, forceJudge)
+      -- Set ID attribute if this sub-example has an ID
+      if parsedDiv.subExIDs and parsedDiv.subExIDs[i] then
+        result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[i])
+      end
       isInterlinear[resultCount] = true
       resultCount = resultCount + 1
     elseif parsedDiv.kind[i] == "single" then
@@ -850,6 +907,10 @@ function pandocMakeMixedList (parsedDiv)
       if parsedDiv.kind[i+1] ~= "single" then
         local to = i
         result[resultCount]        = pandocMakeList(parsedDiv, from, to, forceJudge)
+        -- For single-line list, check if any items have IDs (just use first for now)
+        if parsedDiv.subExIDs and parsedDiv.subExIDs[from] then
+          result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[from])
+        end
         isInterlinear[resultCount] = false
         resultCount = resultCount + 1
       end
@@ -1531,6 +1592,25 @@ end
 function makeCrossrefs (cite)
 
   local id = cite.citations[1].id
+  
+  -- Check if this is a sub-example reference
+  if subExIndex[id] ~= nil then
+    local subEx = subExIndex[id]
+    local parentID = subEx.parentExID
+    local letter = subEx.letter
+    local parentNumber = indexEx[parentID]
+    
+    -- Format as (1a), (2b), etc. with no space
+    if FORMAT:match "latex" then
+      if latexPackage == "expex" then
+        return pandoc.RawInline("latex", "(\\getref{"..parentID.."}"..letter..")")
+      else
+        return pandoc.RawInline("latex", "(\\ref{"..parentID.."}"..letter..")")
+      end
+    else
+      return pandoc.Link("("..parentNumber..letter..")", "#"..id)
+    end
+  end
 
   -- ignore other "cite" elements
   if indexEx[id] ~= nil then 
@@ -1539,13 +1619,14 @@ function makeCrossrefs (cite)
     local suffix = ""
     if #cite.citations[1].suffix > 0 then
       suffix = pandoc.utils.stringify(cite.citations[1].suffix[2])
+      -- For backwards compatibility: append suffix to number ([@ex:parent b])
       suffix = xrefSuffixSep..suffix
     end
 
     -- prevent Latex error when user sets xrefSuffixSep to space or nothing
     if FORMAT:match "latex" then
       if xrefSuffixSep == " " or -- space
-        xrefSuffixSep == " "    -- non-breaking space
+        xrefSuffixSep == " "    -- non-breaking space
       then
         xrefSuffixSep = "\\," -- set to thin space
       end
@@ -1558,7 +1639,7 @@ function makeCrossrefs (cite)
       else
         return pandoc.RawInline("latex", "(\\ref{"..id.."}"..suffix..")")
       end
-    else	
+    else
       return pandoc.Link("("..indexEx[id]..suffix..")", "#"..id)
     end
 

--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -352,11 +352,14 @@ function parseDiv (div)
         local subID = string.match(lineText, "{#([^}]+)}")
         if subID then
           subExIDs[i] = subID
-          -- Remove the {#id} from the actual content
+          -- Remove the {#id} from the actual content and trim whitespace
           for j = #firstLine, 1, -1 do
             local elem = firstLine[j]
             if elem.tag == "Str" and string.match(elem.text, "{#[^}]+}") then
-              firstLine[j] = pandoc.Str(string.gsub(elem.text, "%s*{#[^}]+}", ""))
+              local cleaned = string.gsub(elem.text, "%s*{#[^}]+}%s*", " ")
+              cleaned = string.gsub(cleaned, "^%s+", "")  -- trim leading
+              cleaned = string.gsub(cleaned, "%s+$", "")  -- trim trailing
+              firstLine[j] = pandoc.Str(cleaned)
               break
             end
           end
@@ -368,11 +371,14 @@ function parseDiv (div)
         local subID = string.match(contentText, "{#([^}]+)}")
         if subID then
           subExIDs[i] = subID
-          -- Remove the {#id} from the actual content
+          -- Remove the {#id} from the actual content and trim whitespace
           for j = #content, 1, -1 do
             local elem = content[j]
             if elem.tag == "Str" and string.match(elem.text, "{#[^}]+}") then
-              content[j] = pandoc.Str(string.gsub(elem.text, "%s*{#[^}]+}", ""))
+              local cleaned = string.gsub(elem.text, "%s*{#[^}]+}%s*", " ")
+              cleaned = string.gsub(cleaned, "^%s+", "")  -- trim leading
+              cleaned = string.gsub(cleaned, "%s+$", "")  -- trim trailing
+              content[j] = pandoc.Str(cleaned)
               break
             end
           end
@@ -598,13 +604,13 @@ function pandocMakeExample (parsedDiv)
     example[1] = pandocMakeSingle(parsedDiv)
     -- Set ID if this single example has a sub-example ID
     if parsedDiv.subExIDs and parsedDiv.subExIDs[1] then
-      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1])
+      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1], {"linguistic-example"})
     end
   elseif #kind == 1 and kind[1] == "interlinear" then
     example[1] = pandocMakeInterlinear(parsedDiv)
     -- Set ID if this interlinear has a sub-example ID
     if parsedDiv.subExIDs and parsedDiv.subExIDs[1] then
-      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1])
+      example[1].attr = pandoc.Attr(parsedDiv.subExIDs[1], {"linguistic-example"})
     end
   elseif #kind > 1 and onlySingle then
     example[1] = pandocMakeList(parsedDiv)
@@ -694,7 +700,12 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
   local interlinear = parsedDiv.examples[selection]
   
   local header = {{ interlinear.header }}
-  local headerPresent = interlinear.header.content[1] ~= nil
+  -- Check if header is present AND has meaningful content (not just empty/whitespace)
+  local headerPresent = false
+  if interlinear.header.content[1] ~= nil then
+    local headerText = pandoc.utils.stringify(interlinear.header)
+    headerPresent = headerText:match("%S") ~= nil  -- has non-whitespace
+  end
   local source = interlinear.source 
   for i=1,#source do source[i] = { source[i] } end
   local gloss =  interlinear.gloss 
@@ -896,7 +907,7 @@ function pandocMakeMixedList (parsedDiv)
       result[resultCount]        = pandocMakeInterlinear(parsedDiv, label, forceJudge)
       -- Set ID attribute if this sub-example has an ID
       if parsedDiv.subExIDs and parsedDiv.subExIDs[i] then
-        result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[i])
+        result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[i], {"linguistic-example"})
       end
       isInterlinear[resultCount] = true
       resultCount = resultCount + 1
@@ -909,7 +920,7 @@ function pandocMakeMixedList (parsedDiv)
         result[resultCount]        = pandocMakeList(parsedDiv, from, to, forceJudge)
         -- For single-line list, check if any items have IDs (just use first for now)
         if parsedDiv.subExIDs and parsedDiv.subExIDs[from] then
-          result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[from])
+          result[resultCount].attr = pandoc.Attr(parsedDiv.subExIDs[from], {"linguistic-example"})
         end
         isInterlinear[resultCount] = false
         resultCount = resultCount + 1

--- a/readme.md
+++ b/readme.md
@@ -230,9 +230,47 @@ This is a test
 
 Inspired by the `linguex`-approach, you can also use the keywords `next` or `last` to refer to the next or the last example, e.g. `[@last]` will be formatted as [@last]. By doubling the first letters to `nnext` or `llast` reference to the next/last-but-one can be made. Actually, the number of starting letters can be repeated at will in `pandoc-ling`, so something like `[@llllllllast]` will also work. It will be formatted as [@llllllllast] after the processing of `pandoc-ling`. Needless to say that in such a situation an explicit identifier would be a better choice.
 
-Referring to sub-examples can be done by manually adding a suffix into the cross reference, simply separated from the identifier by a space. For example, `[@lllast c]` will refer to the third sub-example of the last-but-two example. Formatted this will look like this: [@llast c], smile! However, note that the "c" has to be manually determined. It is simply a literal suffix that will be copied into the cross-reference. Something like `[@last hA1l0]` will work also, leading to [@last hA1l0] when formatted (which is of course nonsensical).
+### Referring to sub-examples
 
-For exports that include attributes (like html), the examples have an explicit id of the form `exNUMBER` in which `NUMBER` is the actual number as given in the formatted output. This means that it is possible to refer to an example on any web-page by using the hash-mechanism to refer to a part of the web-page. For example `#ex4.7` at can be used to refer to the seventh example in the html-output of this readme (try [this link](https://cysouw.github.io/pandoc-ling/readme.html#ex4.7)). The id in this example has a chapter number '4' because in the html conversion I have set the option `addChapterNumber` to `true`. (Note: when numbers restart the count in each chapter with the option `restartAtChapter`, then the id is of the form `exCHAPTER.NUMBER`. This is necessary to resolve clashing ids, as the same number might then be used in different chapters.)
+Sub-examples can be referenced in two ways:
+
+**Direct ID references (recommended):** Assign custom IDs to individual sub-examples by placing `{#id}` in the header line of an interlinear example. The ID marker will be removed from the output, and the sub-example can be referenced directly.
+
+```
+:::ex
+a.
+| {#ex:dutch} Dutch (Germanic)
+| Deze zin is in het nederlands.
+| DEM sentence AUX in DET dutch.
+| This sentence is dutch.
+
+b.
+| {#ex:mapudungun} Mapudungun (Isolate)
+| küpatueyew chi ḻuan
+| come-APPL-INV-IND-3-3ACT DEF guanaco
+| 'The guanaco came to him.'
+:::
+```
+
+References to these sub-examples use the direct ID: `[@ex:dutch]` will format as (1a) and `[@ex:mapudungun]` as (1b), with no space between number and letter.
+
+When the header is empty (e.g., in a grammar where all examples are from the same language), place the ID on the otherwise empty header line:
+
+```
+:::ex
+a.
+| {#ex:first}
+| Deze zin is in het nederlands.
+| DEM sentence AUX in DET dutch.
+| This sentence is dutch.
+:::
+```
+
+**Manual suffix references (backwards compatible):** The older method of manually adding a suffix into the cross reference, simply separated from the identifier by a space, still works. For example, `[@lllast c]` will refer to the third sub-example of the last-but-two example. Formatted this will look like this: [@llast c], smile! However, note that the "c" has to be manually determined. It is simply a literal suffix that will be copied into the cross-reference. Something like `[@last hA1l0]` will work also, leading to [@last hA1l0] when formatted (which is of course nonsensical).
+
+The direct ID method is recommended for most use cases as it provides stable references that don't change when sub-examples are reordered.
+
+For exports that include attributes (like html), the examples have an explicit id of the form `exNUMBER` in which `NUMBER` is the actual number as given in the formatted output. Sub-examples with custom IDs are also available as HTML anchors and can be linked directly. This means that it is possible to refer to an example on any web-page by using the hash-mechanism to refer to a part of the web-page. For example `#ex4.7` at can be used to refer to the seventh example in the html-output of this readme (try [this link](https://cysouw.github.io/pandoc-ling/readme.html#ex4.7)). The id in this example has a chapter number '4' because in the html conversion I have set the option `addChapterNumber` to `true`. (Note: when numbers restart the count in each chapter with the option `restartAtChapter`, then the id is of the form `exCHAPTER.NUMBER`. This is necessary to resolve clashing ids, as the same number might then be used in different chapters.)
 
 I propose to use these ids also to refer to examples in citations when writing scholarly papers, e.g. (Cysouw 2021: #ex7), independent of whether the links actually resolve. In principle, such citations could easily be resolved when online publications are properly prepared. The same proposal could also work for other parts of research papers, for example using tags like `#sec, #fig, #tab, #eq` (see the Pandoc filter [`crossref-adapt`](https://github.com/cysouw/crossref-adapt)). To refer to paragraphs (which should replace page numbers in a future of adaptive design), I propose to use no tag, but directly add the number to the hash (see the Pandoc filter [`count-para`](https://github.com/cysouw/count-para) for a practical mechanism to add such numbering).
 


### PR DESCRIPTION
This PR adds the ability to assign custom IDs to individual sub-examples and reference them directly, without manually specifying the letter suffix.

## Syntax

Place `{#id}` in the header line of an interlinear example:

```markdown
::: {#ex:example1 .ex}
a.
| {#ex:dutch} Dutch (Germanic)
| Deze zin is in het nederlands.
| DEM sentence AUX in DET dutch.
| This sentence is dutch.

b.
| {#ex:mapudungun} Mapudungun (Isolate)
| küpatueyew chi ḻuan
| come-APPL-INV-IND-3-3ACT DEF guanaco
| 'The guanaco came to him.'
:::
```

The ID marker is removed from the output, leaving clean language headers.

## References

Direct references to sub-examples:
- `[@ex:dutch]` → (1a)
- `[@ex:mapudungun]` → (1b)

The reference format uses no space between the number and letter, matching the parent example's automatic numbering.

## Backwards compatibility

The old manual suffix syntax continues to work:
- `[@ex:example1 a]` → (1 a)
- `[@last b]` → (1 b)

Both methods can coexist in the same document.

## Benefits

- **Stable references**: Sub-example IDs don't break when reordering
- **Empty headers**: Works with `| {#id}` for language-consistent examples
- **HTML anchors**: Custom IDs are available as direct links in HTML output
