### PR TITLE
more robust `formatGloss` option

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -459,19 +459,69 @@ end
 
 function formatGlossLine (s)
   -- turn uppercase in gloss into small caps
+  -- Only fully uppercase components are treated as glosses
+  
+  -- Check if this is a name abbreviation (e.g., "A." or "B.")
+  -- These end with a period and are typically short
+  if string.match(s, "^[%u][%u]?%.$") then
+    -- Name abbreviation - don't format
+    return {pandoc.Str(s)}
+  end
+  
+  -- Check if this looks like a proper name (starts with capital, then lowercase, no separators)
+  if string.match(s, "^[%u][%l][%l]") and not string.match(s, "[%-‑:=<>~%.%d]") then
+    -- Likely a proper name (e.g., "Antonio") - don't format
+    return {pandoc.Str(s)}
+  end
+  
   local split = {}
-  for lower,upper in string.gmatch(s, "(.-)([%u%d]+)") do
-    if lower ~= "" then
-      lower = pandoc.Str(lower)
-      table.insert(split, lower)
+  local pos = 1
+  
+  while pos <= #s do
+    -- Try to match lowercase/separator sequence
+    local lower_start, lower_end = string.find(s, "^[^%u%d]+", pos)
+    if lower_start then
+      table.insert(split, pandoc.Str(string.sub(s, lower_start, lower_end)))
+      pos = lower_end + 1
     end
-    upper = pandoc.SmallCaps(pandoc.text.lower(upper))
-    table.insert(split, upper)
+    
+    if pos <= #s then
+      -- Try to match an uppercase/digit sequence
+      local upper_start, upper_end = string.find(s, "^[%u%d]+", pos)
+      if upper_start then
+        local upper_text = string.sub(s, upper_start, upper_end)
+        -- Check if this uppercase sequence is followed by lowercase (making it mixed case)
+        local next_pos = upper_end + 1
+        if next_pos <= #s then
+          local next_char = string.sub(s, next_pos, next_pos)
+          if string.match(next_char, "%l") then
+            -- Mixed case (e.g., "Ind") - don't convert, treat whole thing as regular text
+            -- Find the end of this mixed-case word
+            local mixed_end = string.find(s, "[^%a%d]", next_pos)
+            if mixed_end then
+              mixed_end = mixed_end - 1
+            else
+              mixed_end = #s
+            end
+            table.insert(split, pandoc.Str(string.sub(s, upper_start, mixed_end)))
+            pos = mixed_end + 1
+          else
+            -- Fully uppercase - convert to smallcaps
+            table.insert(split, pandoc.SmallCaps(pandoc.text.lower(upper_text)))
+            pos = next_pos
+          end
+        else
+          -- At end of string and all uppercase - convert
+          table.insert(split, pandoc.SmallCaps(pandoc.text.lower(upper_text)))
+          pos = next_pos
+        end
+      else
+        -- Shouldn't happen, but handle gracefully
+        pos = pos + 1
+      end
+    end
   end
-  for leftover in string.gmatch(s, "[%u%d]+([‑%-:=<>~][^‑%-:=<>~]-%l+)$") do
-    leftover = pandoc.Str(leftover)
-    table.insert(split, leftover)
-  end
+  
   if #split == 0 then
     if s == "~" then s = "   " end -- sequence "space-nobreakspace-space"
     table.insert(split, pandoc.Str(s))


### PR DESCRIPTION
This PR fixes several issues with the `formatGloss` option that caused incorrect identification and formatting of gloss abbreviations.

## Problems Fixed

1. **Mixed-case abbreviations** like "Ind" or "3Du" were being partially converted to smallcaps (e.g., `INDu` → <span class="smallcaps">i</span>nd), when they should be left untouched since they're not proper gloss abbreviations.

2. **Name abbreviations** like "A." or "J." were being treated as glosses and converted to smallcaps, when they should be preserved as-is.

3. **Proper names** like "Antonio" appearing in glosses were being truncated or incorrectly formatted.

## New Behavior

The `formatGloss` option now only converts **fully uppercase** components to smallcaps:

```markdown
::: {#ex:mixed-case .ex formatGloss=true}
Mixed case glosses (should NOT be converted):

| Example language
| word1-word2-word3
| follow-Ind-3Du-Past
| 'Translation with mixed case abbreviations.'
:::

::: {#ex:name-abbrev .ex formatGloss=true}
Name abbreviations (should NOT be converted):

| Example with names
| Juan Maria Antonio
| J. M. A.
| 'Juan, Maria, Antonio.'
:::

::: {#ex:proper-names .ex formatGloss=true}
Proper names in glosses (should NOT be converted):

| inaneyngu Antonio
| ina-ne-i-ŋu antonjo
| follow-have-IND-3DU Antonio
| 'They were pursuing Antonio.'
:::
```

## Conversion Rules

- **Fully uppercase** (e.g., `IND`, `3DU`, `IMPF`) → converted to smallcaps
- **Mixed case** (e.g., `Ind`, `3Du`, `Past`) → left as-is
- **Name abbreviations** (e.g., `A.`, `J.`) → left as-is
- **Proper names** (e.g., `Antonio`, `Spanish`) → left as-is
- **Period-separated glosses** (e.g., `3A.SG`, `APPL.DIR`) → each fully uppercase component converted to smallcaps

This ensures that only clear glossing abbreviations (fully uppercase) are formatted, while personal names, mixed-case words, and name abbreviations remain untouched.

