### PR TITLE
Add support for 5-line interlinear examples

### DIFF
--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -1240,7 +1240,8 @@ function texMakeLinguex (parsedDiv)
       source = texCombine(source)
       gloss  = texCombine(gloss)
 
-      if pandoc.utils.stringify(header) == "" then
+      local headerEmpty = pandoc.utils.stringify(header) == ""
+      if headerEmpty then
         header = pandoc.List()
       end
       
@@ -1256,8 +1257,8 @@ function texMakeLinguex (parsedDiv)
       --  texFront("\n  ", header)
       end
       
-      -- Add line break after first header if there's a second header
-      if header2 then
+      -- Add line break after first header if there's a second header AND header is not empty
+      if header2 and not headerEmpty then
         texEnd("\\\\", header)
       end
 

--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -1120,6 +1120,7 @@ function texMakeExpex (parsedDiv)
     elseif kind[i] == "interlinear" then
 
       header = parsedDiv.examples[i].header.content
+      local header2 = parsedDiv.examples[i].header2 and parsedDiv.examples[i].header2.content or nil
       source = parsedDiv.examples[i].source
       gloss  = parsedDiv.examples[i].gloss
       trans  = parsedDiv.examples[i].trans.content
@@ -1133,6 +1134,13 @@ function texMakeExpex (parsedDiv)
         texFront("\n  \\glpreamble ", header)
         texEnd("//", header)
       end
+      
+      if header2 and pandoc.utils.stringify(header2) == "" then
+        header2 = nil
+      elseif header2 then
+        texFront("\n  \\glpreamble ", header2)
+        texEnd("//", header2)
+      end
 
       if #kind > 1 then 
         texEnd("\n  \\a ", preamble)
@@ -1140,6 +1148,12 @@ function texMakeExpex (parsedDiv)
 
       texEnd("\n  \\begingl", preamble)
       preamble:extend(header)
+      
+      -- Add second header if present
+      if header2 then
+        preamble:extend(header2)
+      end
+      
       texFront("\n  \\gla ", judgements[i])
       preamble:extend(judgements[i])
       texEnd("//", source)
@@ -1218,6 +1232,7 @@ function texMakeLinguex (parsedDiv)
     elseif kind[i] == "interlinear" then
 
       header = parsedDiv.examples[i].header.content
+      local header2 = parsedDiv.examples[i].header2 and parsedDiv.examples[i].header2.content or nil
       source = parsedDiv.examples[i].source
       gloss  = parsedDiv.examples[i].gloss
       trans  = parsedDiv.examples[i].trans.content
@@ -1228,6 +1243,10 @@ function texMakeLinguex (parsedDiv)
       if pandoc.utils.stringify(header) == "" then
         header = pandoc.List()
       end
+      
+      if header2 and pandoc.utils.stringify(header2) == "" then
+        header2 = nil
+      end
 
       if #kind > 1 and i == 1 then 
         texFront("\n  \\a. ", header)
@@ -1236,8 +1255,20 @@ function texMakeLinguex (parsedDiv)
       --else
       --  texFront("\n  ", header)
       end
+      
+      -- Add line break after first header if there's a second header
+      if header2 then
+        texEnd("\\\\", header)
+      end
 
       preamble:extend(header)
+      
+      -- Add second header if present
+      if header2 then
+        texFront("\n      ", header2)
+        preamble:extend(header2)
+      end
+      
       texFront("\n  \\gll ", judgements[i])
       preamble:extend(judgements[i])
       texEnd("\\\\", source)
@@ -1324,6 +1355,7 @@ function texMakeGb4e (parsedDiv)
     elseif kind[i] == "interlinear" then
 
       header = parsedDiv.examples[i].header.content
+      local header2 = parsedDiv.examples[i].header2 and parsedDiv.examples[i].header2.content or nil
       source = parsedDiv.examples[i].source
       gloss  = parsedDiv.examples[i].gloss
       trans  = parsedDiv.examples[i].trans.content
@@ -1333,7 +1365,18 @@ function texMakeGb4e (parsedDiv)
 
       if pandoc.utils.stringify(header) == "" then
         header = pandoc.List()
-      else texFront("\n       ", header)
+      else 
+        texFront("\n       ", header)
+        -- Add line break after first header if there's a second header
+        if header2 then
+          texEnd("\\\\", header)
+        end
+      end
+      
+      if header2 and pandoc.utils.stringify(header2) == "" then
+        header2 = nil
+      elseif header2 then
+        texFront("\n       ", header2)
       end
 
       if #kind > 1 and i == 1 then 
@@ -1346,6 +1389,12 @@ function texMakeGb4e (parsedDiv)
 
       preamble:extend(judgements[i])
       preamble:extend(header)
+      
+      -- Add second header if present
+      if header2 then
+        preamble:extend(header2)
+      end
+      
       texFront("\n  \\gll ", source)
       texEnd("\\\\", source)
       preamble:extend(source)
@@ -1454,6 +1503,7 @@ function texMakeLangsci (parsedDiv)
     elseif kind[i] == "interlinear" then
 
       header = parsedDiv.examples[i].header.content
+      local header2 = parsedDiv.examples[i].header2 and parsedDiv.examples[i].header2.content or nil
       source = parsedDiv.examples[i].source
       gloss  = parsedDiv.examples[i].gloss
       trans  = parsedDiv.examples[i].trans.content
@@ -1467,6 +1517,13 @@ function texMakeLangsci (parsedDiv)
         texFront("\n       ", header)
         texEnd("\\\\*", header)
       end
+      
+      if header2 and pandoc.utils.stringify(header2) == "" then
+        header2 = nil
+      elseif header2 then
+        texFront("\n       ", header2)
+        texEnd("\\\\*", header2)
+      end
 
       if #kind > 1 and i == 1 then 
         texFront("\n  \\ea ", judgements[i])
@@ -1477,6 +1534,12 @@ function texMakeLangsci (parsedDiv)
       end
 
       preamble:extend(header)
+      
+      -- Add second header if present
+      if header2 then
+        preamble:extend(header2)
+      end
+      
       texFront("\n  \\gll ", source)
       texEnd("\\\\", source)
       preamble:extend(source)

--- a/pandoc-ling.lua
+++ b/pandoc-ling.lua
@@ -385,25 +385,63 @@ end
 function parseInterlinear (block)
 
   local interlinear = {}
-  local judgement, source = splitJudgement( block[2] )
-
-  -- header
-  local header = block[1]
-  for i=1,#header do
-    if header[i].text == "\\" then
-      header[i] = pandoc.LineBreak()
+  local judgement, source
+  
+  -- Detect structure based on number of lines
+  if #block == 5 then
+    -- 5 lines: header1, header2, source, gloss, translation
+    -- header1
+    local header = block[1]
+    for i=1,#header do
+      if header[i].text == "\\" then
+        header[i] = pandoc.LineBreak()
+      end
     end
+    interlinear["header"] = pandoc.Plain(header)
+    
+    -- header2
+    local header2 = block[2]
+    for i=1,#header2 do
+      if header2[i].text == "\\" then
+        header2[i] = pandoc.LineBreak()
+      end
+    end
+    interlinear["header2"] = pandoc.Plain(header2)
+    
+    -- source (with judgement)
+    judgement, source = splitJudgement( block[3] )
+    interlinear["source"] = splitSource(source)
+    
+    -- gloss
+    interlinear["gloss"] = splitGloss( block[4] )
+    
+    -- translation
+    interlinear["trans"] = getTrans( block[5] )
+    
+  else
+    -- 3-4 lines: [header], source, gloss, translation
+    judgement, source = splitJudgement( block[2] )
+    
+    -- header
+    local header = block[1]
+    for i=1,#header do
+      if header[i].text == "\\" then
+        header[i] = pandoc.LineBreak()
+      end
+    end
+    interlinear["header"] = pandoc.Plain(header)
+    interlinear["header2"] = nil
+    
+    -- source
+    interlinear["source"] = splitSource(source)
+    -- gloss
+    interlinear["gloss"] = splitGloss( block[3] )
+    -- translation
+    interlinear["trans"] = getTrans( block[#block] )
   end
-  interlinear["header"] = pandoc.Plain(header)
-  -- source
-  interlinear["source"] = splitSource(source)
-  -- gloss
-  interlinear["gloss"] = splitGloss( block[3] )
-  -- translation
-  interlinear["trans"] = getTrans( block[#block] )
 
   -- judgement is Str
-  -- (header, trans) in interlinear is Plain
+  -- (header, header2, trans) in interlinear is Plain
   -- (source, gloss) in interlinear is list of Plain
   return judgement, interlinear
 end
@@ -642,6 +680,8 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
   
   local header = {{ interlinear.header }}
   local headerPresent = interlinear.header.content[1] ~= nil
+  local header2 = interlinear.header2 and {{ interlinear.header2 }} or nil
+  local header2Present = header2 ~= nil and interlinear.header2.content[1] ~= nil
   local source = interlinear.source 
   for i=1,#source do source[i] = { source[i] } end
   local gloss =  interlinear.gloss 
@@ -651,6 +691,9 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
   local rowContent = { trans }
     table.insert(rowContent, 1, gloss )
     table.insert(rowContent, 1, source )
+  if header2Present then
+    table.insert(rowContent, 1, header2 )
+  end
   if headerPresent then
     table.insert(rowContent, 1, header )
   end
@@ -665,11 +708,11 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
       nCols =  nCols + 1
       judgeCol = judgeCol + 2
       if judgement == nil then judgement = "" end
-      if headerPresent then
-        rowContent[2][1][1] = pandoc.Plain(judgement)
-      else
-        rowContent[1][1][1] = pandoc.Plain(judgement)
-      end
+      -- Place judgement on the source row
+      local sourceRow = 1
+      if headerPresent then sourceRow = sourceRow + 1 end
+      if header2Present then sourceRow = sourceRow + 1 end
+      rowContent[sourceRow][1][1] = pandoc.Plain(judgement)
     end
   -- add labels
   if label ~= nil then
@@ -697,6 +740,7 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
   local ps = 0 --preambleshift
   local ls = 0 --labelshift
   local hs = 0 --headershift
+  local h2s = 0 --header2shift
   local js = 0 --judgementshift
   if judgeCol > 1 then js = 1 end
 
@@ -721,16 +765,22 @@ function pandocMakeInterlinear (parsedDiv, label, forceJudge)
     example.bodies[1].body[1+ps].cells[2+ls+js].attr = {class =  "linguistic-example-header linguistic-example-content"}
     example.bodies[1].body[1+ps].cells[2+ls+js].col_span = nCols-1-ls-js
   end
+  -- set class of header2 and extend cell
+  if header2Present then
+    h2s = 1
+    example.bodies[1].body[1+ps+hs].cells[2+ls+js].attr = {class =  "linguistic-example-header linguistic-example-content"}
+    example.bodies[1].body[1+ps+hs].cells[2+ls+js].col_span = nCols-1-ls-js
+  end
   -- set class of translation and extend cell
   example.bodies[1].body[nRows].cells[2+ls+js].attr = {class = "linguistic-example-translation linguistic-example-content"}
   example.bodies[1].body[nRows].cells[2+ls+js].col_span = nCols-1-ls-js
   -- set class of judgment
   if judgeCol > 1 then
-    example.bodies[1].body[1+hs+ps].cells[2+ls].attr = {class = "linguistic-example-judgement"}
+    example.bodies[1].body[1+hs+h2s+ps].cells[2+ls].attr = {class = "linguistic-example-judgement"}
   end
   -- set class of source and gloss
   local ssCol = 3 + ls -- sourcestart columns
-  local ssRow = 1 + hs + ps -- sourcestart row
+  local ssRow = 1 + hs + h2s + ps -- sourcestart row
   for i=ssCol,nCols do
     example.bodies[1].body[ssRow].cells[i].attr = {class = "linguistic-example-source linguistic-example-content"}
     example.bodies[1].body[ssRow+1].cells[i].attr = {class = "linguistic-example-gloss linguistic-example-content"}


### PR DESCRIPTION
Extends interlinear support to 5 lines: header₁, header₂, source, gloss, translation.

Use case: orthographic/surface form distinction, language family metadata, or multi-level headers.

## Example

```markdown
::: {.ex formatGloss=true}
| Mapudungun (Isolate)
| amuymi
| amu-i-m-i
| go-IND-2-SG
| 'You went'
:::
```

## Implementation

**HTML output:**  
Both headers rendered as separate `<tr>` rows with `linguistic-example-header` class, preserving existing CSS styling.

**LaTeX output:**  
Package-specific implementations ensure headers appear on separate lines:

- **linguex/gb4e/langsci-gb4e**: Explicit line break (`\\`) after first header
  ```latex
  \a. Mapudungun (Isolate)\\
      amuymi
  ```

- **expex**: Separate `\glpreamble` commands (naturally multi-line)
  ```latex
  \glpreamble Mapudungun (Isolate)//
  \glpreamble amuymi//
  ```

Modified functions: `parseInterlinear()` (#block == 5 case), `pandocMakeInterlinear()` (header2 row insertion), `texMakeLinguex()`, `texMakeGb4e()`, `texMakeLangsci()`, `texMakeExpex()`.

## Compatibility

✅ Existing 3-4 line examples unchanged  
✅ Works with multi-part examples  
✅ Can mix 4-line and 5-line structures within same document  
✅ All LaTeX packages supported

